### PR TITLE
feat: Add argument for disabling creation of burn rate alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ module "gcp_slos" {
             availability = {
               enabled = true
             }
-          alert:
+          }
+          alert = {
             enabled = true
           }
         }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # tf-module-gcp-slos
 
-Module for creating Service Level Objectives (SLOs) in Google Cloud. The `slo` object in the input follows the same structure as the official [terraform module](https://registry.terraform.io/providers/hashicorp/google/6.0.1/docs/resources/monitoring_slo), which means this module can create whatever SLOs it supports (v6.0.1). By default, this module does not create a **fast-burn** alert for each SLO. Instead creation of burn alerts is controlled with the `create_burn_rate_alert` argument. This alert can be turned off or tweaked by setting the `alert` object in each SLO. More information on the input argument structure can be found below or in [examples](./examples/).
+Module for creating Service Level Objectives (SLOs) in Google Cloud. The `slo` object in the input follows the same structure as the official [terraform module](https://registry.terraform.io/providers/hashicorp/google/6.0.1/docs/resources/monitoring_slo), which means this module can create whatever SLOs it supports (v6.0.1). A burn rate alert can be created using the `alert` argument. This alert can be turned off or tweaked by setting the `alert` object in each SLO. More information on the input argument structure can be found below or in [examples](./examples/).
 
 ## Usage
 
@@ -27,7 +27,8 @@ module "gcp_slos" {
             availability = {
               enabled = true
             }
-          create_burn_rate_alert = true
+          alert:
+            enabled = true
           }
         }
       ]
@@ -80,10 +81,8 @@ services = [
           # ... (structure as per Terraform documentation)
         }
 
-        create_burn_rate_alert  = bool    # Optional, default = false
-
         alert = {
-          enabled               = bool    # Optional
+          enabled               = bool    # Optional, default = false
           title                 = string  # Optional
           documentation         = string  # Optional
           threshold_value       = number  # Optional

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # tf-module-gcp-slos
 
-Module for creating Service Level Objectives (SLOs) in Google Cloud. The `slo` object in the input follows the same structure as the official [terraform module](https://registry.terraform.io/providers/hashicorp/google/6.0.1/docs/resources/monitoring_slo), which means this module can create whatever SLOs it supports (v6.0.1). By default, the module also creates a **fast-burn** alert for each SLO. This alert can be turned off or tweaked by setting the `alert` object in each SLO. More information on the input argument structure can be found below or in [examples](./examples/).
+Module for creating Service Level Objectives (SLOs) in Google Cloud. The `slo` object in the input follows the same structure as the official [terraform module](https://registry.terraform.io/providers/hashicorp/google/6.0.1/docs/resources/monitoring_slo), which means this module can create whatever SLOs it supports (v6.0.1). By default, this module does not create a **fast-burn** alert for each SLO. Instead creation of burn alerts is controlled with the `create_burn_rate_alert` argument. This alert can be turned off or tweaked by setting the `alert` object in each SLO. More information on the input argument structure can be found below or in [examples](./examples/).
 
 ## Usage
 
@@ -27,6 +27,7 @@ module "gcp_slos" {
             availability = {
               enabled = true
             }
+          create_burn_rate_alert = true
           }
         }
       ]
@@ -78,6 +79,8 @@ services = [
         windows_based_sli = {
           # ... (structure as per Terraform documentation)
         }
+
+        create_burn_rate_alert  = bool    # Optional, default = false
 
         alert = {
           enabled               = bool    # Optional

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # tf-module-gcp-slos
 
-Module for creating Service Level Objectives (SLOs) in Google Cloud. The `slo` object in the input follows the same structure as the official [terraform module](https://registry.terraform.io/providers/hashicorp/google/6.0.1/docs/resources/monitoring_slo), which means this module can create whatever SLOs it supports (v6.0.1). A burn rate alert can be created using the `alert` argument. This alert can be turned off or tweaked by setting the `alert` object in each SLO. More information on the input argument structure can be found below or in [examples](./examples/).
+Module for creating Service Level Objectives (SLOs) in Google Cloud. The `slo` object in the input follows the same structure as the official [terraform module](https://registry.terraform.io/providers/hashicorp/google/6.0.1/docs/resources/monitoring_slo), which means this module can create whatever SLOs it supports (v6.0.1). A burn rate alert can be created using the `alert` argument. This alert can be turned on and tweaked by setting the `alert` object in each SLO. More information on the input argument structure can be found below or in [examples](./examples/).
 
 ## Usage
 

--- a/examples/services-and-slos.yaml
+++ b/examples/services-and-slos.yaml
@@ -72,6 +72,7 @@
       availability:
         enabled: true
     alert: # Override default alert policy
+      enabled: true 
       title: Custom alert title
       description: Custom alert description
       lookback_duration: 86400s # 1 day
@@ -79,7 +80,6 @@
       duration: 3600s # 1 hour
       notification_channels:
       - projects/my-project/notificationChannels/my-channel # Override fallback notification channels
-    create_burn_rate_alert: true
 
   - display_name: Create a default burn rate alert for this SLO
     goal: 0.999
@@ -89,4 +89,3 @@
         enabled: true
     alert:
       enabled: true
-    create_burn_rate_alert: true

--- a/examples/services-and-slos.yaml
+++ b/examples/services-and-slos.yaml
@@ -79,12 +79,14 @@
       duration: 3600s # 1 hour
       notification_channels:
       - projects/my-project/notificationChannels/my-channel # Override fallback notification channels
+    create_burn_rate_alert: true
 
-  - display_name: Don't create an alert for this SLO
+  - display_name: Create a default burn rate alert for this SLO
     goal: 0.999
     rolling_period_days: 28
     basic_sli:
       availability:
         enabled: true
     alert:
-      enabled: false
+      enabled: true
+    create_burn_rate_alert: true

--- a/main.tf
+++ b/main.tf
@@ -234,7 +234,7 @@ resource "google_monitoring_alert_policy" "alert_policy" {
     for service in local.services_with_type : [
       for s in service.slos : merge(s, { service_name = service.service.name })
     ]
-  ]) : "${slo.service_name}-${slo.formatted_name}" => slo }
+  ]) : "${slo.service_name}-${slo.formatted_name}" => slo if try(slo.create_burn_rate_alert, true) }
 
   project = var.project
   display_name = try(

--- a/main.tf
+++ b/main.tf
@@ -234,7 +234,7 @@ resource "google_monitoring_alert_policy" "alert_policy" {
     for service in local.services_with_type : [
       for s in service.slos : merge(s, { service_name = service.service.name })
     ]
-  ]) : "${slo.service_name}-${slo.formatted_name}" => slo if try(slo.create_burn_rate_alert, true) }
+  ]) : "${slo.service_name}-${slo.formatted_name}" => slo if lookup(slo, "alert", null) != null && lookup(slo.alert, "enabled", false) }
 
   project = var.project
   display_name = try(


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/0031769e-31f3-4c0d-8cf2-c12ebc1c92f0)

Current SLO config matrix for creating burn rate alerts.